### PR TITLE
Use distroless as base image instead of scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 RUN \
     --mount=type=cache,id=gocache,target=/root/.cache/go-build \
     --mount=type=cache,id=gomodcache,target=/go/pkg \
-    go install
+    go install ./...
 
 FROM gcr.io/distroless/static
 COPY --from=builder /go/bin /bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN \
     --mount=type=cache,id=gomodcache,target=/go/pkg \
     go install
 
-FROM scratch
+FROM gcr.io/distroless/static
 COPY --from=builder /go/bin /bin
 ENV BOT_TOKEN=token
 ENV APP_ID=12345


### PR DESCRIPTION
Changes base image to gcr.io/distroless/static so that base image contains tzdata and TLS root certs.

See https://github.com/GoogleContainerTools/distroless
